### PR TITLE
Fix API auth check

### DIFF
--- a/pages/api/requests.js
+++ b/pages/api/requests.js
@@ -8,7 +8,7 @@ export default async function handler(req, res) {
     const session = await getServerSession(req, res, authOptions); 
 
     if (!session) {
-        return response.status(403).json({ message: "No access" });
+        return res.status(403).json({ message: "No access" });
     }
 
     await dbConnect();


### PR DESCRIPTION
## Summary
- fix incorrect response object in `requests` API

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685915452210833196eeede8d6d69575